### PR TITLE
fix #8

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,8 @@
-import mcData from 'minecraft-data'
+import {IndexedData} from 'minecraft-data'
 
-declare module "prismarine-registry" {
-  export default function(mcVersion: string): ReturnType<typeof mcData>
+declare function loader(mcVersion: string): IndexedData
+declare namespace loader {
+  export type Registry = IndexedData
 }
+
+export = loader

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,18 @@
 import {IndexedData} from 'minecraft-data'
+import {NBT} from 'prismarine-nbt'
 
-declare function loader(mcVersion: string): IndexedData
+declare function loader(mcVersion: string): loader.Registry
 declare namespace loader {
-  export type Registry = IndexedData
+  export interface RegistryPc extends IndexedData {
+    loadDimensionCodec( codec: NBT ): void
+    writeDimensionCodec(): NBT
+  }
+  
+  export interface RegistryBedrock extends IndexedData {
+    
+  }
+  
+  export type Registry = RegistryBedrock | RegistryPc
 }
 
 export = loader


### PR DESCRIPTION
[Typescript Doc](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html#default-exports):
> Note that using `export default` in your .d.ts files requires [esModuleInterop: true](https://www.typescriptlang.org/tsconfig#esModuleInterop) to work. If you can’t have `esModuleInterop: true` in your project, such as when you’re submitting a PR to Definitely Typed, you’ll have to use the `export=` syntax instead. This older syntax is harder to use but works everywhere.

This should also be fixed in other packages!