### PR TITLE
update dimension codec functions for pc1.19

### DIFF
--- a/lib/pc/index.js
+++ b/lib/pc/index.js
@@ -62,6 +62,8 @@ module.exports = (data, staticData) => {
           type: nbt.string('minecraft:worldgen/biome'),
           value: nbt.list(nbt.comp(mcDataSchemaToNetworkBiomes(hasDynamicDimensionData ? data.biomesArray : null, staticData)))
         })
+        // 1.19
+        codec['minecraft:chat_type'] = staticData.loginPacket.dimensionCodec?.value?.['minecraft:chat_type']
       }
 
       return nbt.comp(codec)


### PR DESCRIPTION
There's new field related to chat, but it's not very useful to store so I only updated the writeCodec function.

```json
  "minecraft:chat_type": {
    "type": "minecraft:chat_type",
    "value": [
      {
        "name": "minecraft:chat",
        "id": 0,
        "element": {
          "chat": {
            "decoration": {
              "translation_key": "chat.type.text",
              "style": {},
              "parameters": [
                "sender",
                "content"
              ]
            }
          },
          "narration": {
            "priority": "chat",
            "decoration": {
              "translation_key": "chat.type.text.narrate",
              "style": {},
              "parameters": [
                "sender",
                "content"
              ]
            }
          }
        }
      },
```