### PR TITLE
Parse minecraft:raw chat type

### DIFF
--- a/lib/pc/index.js
+++ b/lib/pc/index.js
@@ -21,7 +21,7 @@ module.exports = (data, staticData) => {
           const n = {
             id: chatType.id,
             name: chatType.name,
-            formatString: staticData.language[d.translation_key],
+            formatString: staticData.language[d.translation_key] || d.translation_key /* chat type minecraft:raw has the formatString given directly by the translation key */,
             parameters: d.parameters
           }
           data.chatFormattingById[chatType.id] = n

--- a/lib/pc/transforms.js
+++ b/lib/pc/transforms.js
@@ -58,11 +58,11 @@ module.exports = {
               ...oldEffects,
               mood_sound: biome.effects?.mood_sound
                 ? nbt.comp({
-                    tick_delay: nbt.int(biome.effects.mood_sound.tick_delay),
-                    offset: nbt.double(biome.effects.mood_sound.offset),
-                    sound: nbt.string(biome.effects.mood_sound.sound),
-                    block_search_extent: nbt.int(biome.effects.mood_sound.block_search_extent)
-                  })
+                  tick_delay: nbt.int(biome.effects.mood_sound.tick_delay),
+                  offset: nbt.double(biome.effects.mood_sound.offset),
+                  sound: nbt.string(biome.effects.mood_sound.sound),
+                  block_search_extent: nbt.int(biome.effects.mood_sound.block_search_extent)
+                })
                 : undefined
             })
           })

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "minecraft-wrap": "^1.4.0",
     "mocha": "^10.0.0",
     "prismarine-registry": "file:.",
-    "standard": "^16.0.1"
+    "standard": "^17.0.0"
   },
   "dependencies": {
     "minecraft-data": "^3.0.0",

--- a/test/util/collectMcpcPackets.js
+++ b/test/util/collectMcpcPackets.js
@@ -8,7 +8,7 @@ async function collectPackets (version, names = ['login'], cb) {
   console.log('Started server')
 
   const client = nmp.createClient({
-    version: version,
+    version,
     host: 'localhost',
     port: 25569,
     username: 'test'


### PR DESCRIPTION
The format string of chat type ´minecraft:raw` is directly given by the translation key. This PR accounts for that.