### PR TITLE
Exporting Registry Type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,5 @@ interface PCRegistry extends IndexedData {
 interface BedrockRegistry extends IndexedData {
 
 }
-type Registry = PCRegistry & BedrockRegistry
-declare function loader(mcVersion: string): Registry
-export = loader
+export type Registry = PCRegistry & BedrockRegistry
+export default function loader(mcVersion: string): Registry


### PR DESCRIPTION
To add types to Mineflayer, etc I need this type. The export default should keep the same thing as before for loader but allows access to Registry too.