### PR TITLE
Namespace agnostic codec lookups

### DIFF
--- a/lib/pc/index.js
+++ b/lib/pc/index.js
@@ -11,7 +11,11 @@ module.exports = (data, staticData) => {
     loadDimensionCodec (codec) {
       const dimensionCodec = nbt.simplify(codec)
 
-      const chat = dimensionCodec['minecraft:chat_type']?.value
+      Object.keys(dimensionCodec).forEach(key => {
+        dimensionCodec[key.replace('minecraft:', '')] = dimensionCodec[key];
+      });
+
+      const chat = dimensionCodec['chat_type']?.value
       if (chat) {
         data.chatFormattingById = {}
         data.chatFormattingByName = {}
@@ -30,7 +34,7 @@ module.exports = (data, staticData) => {
         }
       }
 
-      const dimensions = dimensionCodec['minecraft:dimension_type']?.value
+      const dimensions = dimensionCodec['dimension_type']?.value
       if (dimensions) {
         data.dimensionsById = {}
         data.dimensionsByName = {}
@@ -46,7 +50,7 @@ module.exports = (data, staticData) => {
         }
       }
 
-      const biomes = dimensionCodec['minecraft:worldgen/biome']?.value
+      const biomes = dimensionCodec['worldgen/biome']?.value
       if (!biomes) {
         return // no biome data
       }


### PR DESCRIPTION
Hardcoded lookup on `minecraft:` namespace causes errors on some server software that sends codec without namespaces. This fixes it (albeit not very beautifully)

Closes #34