### PR TITLE
Optional `minecraft:` prefix

### DIFF
--- a/lib/pc/index.js
+++ b/lib/pc/index.js
@@ -4,6 +4,10 @@ nbt.float = value => ({ type: 'float', value })
 
 const { networkBiomesToMcDataSchema, mcDataSchemaToNetworkBiomes } = require('./transforms')
 
+const getEntry = (obj, key) => obj?.[key] ?? obj?.['minecraft:' + key]
+// TODO depending on the MC version, entries need to be prefixed with "minecraft:" or not
+const setEntry = (obj, key, val) => obj[key] = val
+
 module.exports = (data, staticData) => {
   let hasDynamicDimensionData = false
 
@@ -11,7 +15,7 @@ module.exports = (data, staticData) => {
     loadDimensionCodec (codec) {
       const dimensionCodec = nbt.simplify(codec)
 
-      const chat = dimensionCodec['minecraft:chat_type']?.value
+      const chat = getEntry(dimensionCodec, 'chat_type')?.value
       if (chat) {
         data.chatFormattingById = {}
         data.chatFormattingByName = {}
@@ -22,15 +26,14 @@ module.exports = (data, staticData) => {
             id: chatType.id,
             name: chatType.name,
             formatString: staticData.language[d.translation_key] || d.translation_key /* chat type minecraft:raw has the formatString given directly by the translation key */,
-            parameters: d.parameters,
-            style: d.style
+            parameters: d.parameters
           }
           data.chatFormattingById[chatType.id] = n
           data.chatFormattingByName[chatType.name] = n
         }
       }
 
-      const dimensions = dimensionCodec['minecraft:dimension_type']?.value
+      const dimensions = getEntry(dimensionCodec, 'dimension_type')?.value
       if (dimensions) {
         data.dimensionsById = {}
         data.dimensionsByName = {}
@@ -46,7 +49,7 @@ module.exports = (data, staticData) => {
         }
       }
 
-      const biomes = dimensionCodec['minecraft:worldgen/biome']?.value
+      const biomes = getEntry(dimensionCodec, 'worldgen/biome')?.value
       if (!biomes) {
         return // no biome data
       }
@@ -78,7 +81,7 @@ module.exports = (data, staticData) => {
         // Keep the old dimension codec data if it exists (re-encoding)
         // We don't have this data statically, should probably be added to mcData
         if (data.dimensionsArray) {
-          codec['minecraft:dimension_type'] = nbt.comp({
+          setEntry(codec, 'dimension_type', nbt.comp({
             type: nbt.string('minecraft:dimension_type'),
             value: nbt.list(nbt.comp(
               data.dimensionsArray.map(dimension => ({
@@ -87,19 +90,19 @@ module.exports = (data, staticData) => {
                 element: dimension.element
               }))
             ))
-          })
+          }))
         } else {
-          codec['minecraft:dimension_type'] = staticData.loginPacket.dimensionCodec.value['minecraft:dimension_type']
+          setEntry(codec, 'dimension_type', getEntry(staticData.loginPacket.dimensionCodec.value, 'dimension_type'))
         }
 
         // if we have dynamic biome data (re-encoding), we can count on biome.effects
         // being in place. Otherwise, we need to use static data exclusively, e.g. flying squid.
-        codec['minecraft:worldgen/biome'] = nbt.comp({
+        setEntry(codec, 'worldgen/biome', nbt.comp({
           type: nbt.string('minecraft:worldgen/biome'),
           value: nbt.list(nbt.comp(mcDataSchemaToNetworkBiomes(hasDynamicDimensionData ? data.biomesArray : null, staticData)))
-        })
+        }))
         // 1.19
-        codec['minecraft:chat_type'] = staticData.loginPacket.dimensionCodec?.value?.['minecraft:chat_type']
+        setEntry(codec, 'chat_type', getEntry(staticData.loginPacket.dimensionCodec?.value, 'chat_type'))
       }
 
       return nbt.comp(codec)

--- a/lib/pc/index.js
+++ b/lib/pc/index.js
@@ -6,7 +6,9 @@ const { networkBiomesToMcDataSchema, mcDataSchemaToNetworkBiomes } = require('./
 
 const getEntry = (obj, key) => obj?.[key] ?? obj?.['minecraft:' + key]
 // TODO depending on the MC version, entries need to be prefixed with "minecraft:" or not
-const setEntry = (obj, key, val) => obj[key] = val
+const setEntry = (obj, key, val) => {
+  obj[key] = val
+}
 
 module.exports = (data, staticData) => {
   let hasDynamicDimensionData = false


### PR DESCRIPTION
See #34 for the problem. This is currently only a partial fix, but it gets things mostly working.
Alternative solutions are #35, #37, #38.

- [x] When reading, try `thefield` with `minecraft:thefield` as fallback (happy path for newer versions)
- [ ] When assigning, add `minecraft:` depending on the version

I currently do not intend to work on this further but these changes solved most issues for me so I am uploading them here for anyone to use/complete.