### PR TITLE
Switch to trusted publishing via OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master # Change this to your default branch
+permissions:
+  id-token: write
+  contents: write
 jobs:
   npm-publish:
     name: npm-publish
@@ -13,11 +16,10 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@master
       with:
-        node-version: 22.0.0
+        node-version: 24
+        registry-url: 'https://registry.npmjs.org'
     - id: publish
-      uses: JS-DevTools/npm-publish@v1
-      with:
-        token: ${{ secrets.NPM_AUTH_TOKEN }}
+      uses: JS-DevTools/npm-publish@v4
     - name: Create Release
       if: steps.publish.outputs.type != 'none'
       id: create_release


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission for OIDC trusted publishing
- Use Node 24 (ships npm 11.11.0, trusted publishing requires >=11.5.1)
- Add `registry-url` for OIDC auth flow
- Upgrade `JS-DevTools/npm-publish` from v1 to v4
- Remove `NPM_AUTH_TOKEN` (no longer needed with trusted publishers)

Trusted publisher already configured on npmjs.com for this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)